### PR TITLE
Update bulk_download.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,9 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.9.0
 commit = True
 tag = True
 
 [bumpversion:file:setup.py]
 
 [bumpversion:file:mg_toolkit/__init__.py]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: v3.2.0
     hooks:
       - id: trailing-whitespace
-        exclude: '^tests/*'
+        exclude: '^tests/*|.bumpversion.cfg'
       - id: end-of-file-fixer
-        exclude: '^tests/*'
+        exclude: '^tests/*|.bumpversion.cfg'
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/mg_toolkit/__init__.py
+++ b/mg_toolkit/__init__.py
@@ -20,4 +20,4 @@ from mg_toolkit.bulk_download import bulk_download
 
 __all__ = ["original_metadata", "sequence_search", "bulk_download"]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/mg_toolkit/bulk_download.py
+++ b/mg_toolkit/bulk_download.py
@@ -226,7 +226,7 @@ class BulkDownloader:
 
             while total_results_processed < num_results:
 
-                num_results_processed += self.process_page(response_data, progress_bar)
+                num_results_processed = self.process_page(response_data, progress_bar)
                 total_results_processed += num_results_processed
 
                 # navigate to the next link

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["ez_setup"]),
-    version="0.8.0",
+    version="0.9.0",
     python_requires=">=3.5",
     install_requires=install_requirements,
     setup_requires=["pytest-runner"],


### PR DESCRIPTION
I don't think this += is intentional.

Currently if process_page returns 25, then through five pages num_results_processed is [25, 50, 75, 100, 125] and total_results_processed is [25, 75, 150, 250, 375] when total_results_processed should be 125.

This fix seems sufficient to fix problem.