### PR TITLE
Bugfix: handle bad responses from ENA browser API

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.3
+current_version = 0.10.4
 commit = True
 tag = True
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ target/
 #IntelliJ project structure files
 *.iml
 .idea
+venv*

--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ erp001736 = OriginalMetadata('ERP001736')
 erp001736.fetch_metadata()
 ```
 
+
+Development setup
+=================
+Install the package in edit mode, and additional dev requirements (pre-commit hooks and version bumper).
+```shell
+pip install -e . -r requirements-dev.txt
+pre-commit install
+```
+
+You can bump the version with e.g. `bump2version patch`.
+
+
 Contributors
 ============
 

--- a/mg_toolkit/__init__.py
+++ b/mg_toolkit/__init__.py
@@ -20,4 +20,4 @@ from mg_toolkit.search import sequence_search
 
 __all__ = ["original_metadata", "sequence_search", "bulk_download"]
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"

--- a/mg_toolkit/constants.py
+++ b/mg_toolkit/constants.py
@@ -28,3 +28,6 @@ MG_ANALYSES_DOWNLOADS_URL = API_BASE + "/analyses/{accession}/downloads"
 
 ENA_SEARCH_API_URL = "https://www.ebi.ac.uk/ena/portal/api/search"
 ENA_XML_VIEW_URL = "https://www.ebi.ac.uk/ena/browser/api/xml"
+
+EBI_URL_PREFIX = "https://www.ebi.ac.uk/"
+REQUESTS_RETRIES = 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@
 # install and create a virtual environment
 # run pip install -r requirements
 
-requests>=2.24.0
+requests>=2.31.0
 pandas==2.0.3
 jsonapi-client>=0.9.9
 tqdm>=4.49.0
+
+urllib3~=2.2.1

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["ez_setup"]),
-    version="0.10.3",
+    version="0.10.4",
     python_requires=">=3.8",
     install_requires=install_requirements,
     setup_requires=["pytest-runner"],


### PR DESCRIPTION
Sometimes, the ENA Browser API will return 50x errors when fetching XML is the `original_metadata` subcommand. These were not being handled. This PR adds a Retry mechanism which catches these transient errors; in my testing 1 retry is always enough but it's set at 3 with exponential backoff for safety.